### PR TITLE
Use generic CentOS boxes for testing built RPMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ del.vm.centos8:
 	@ansible-playbook --inventory localhost, ./ansible/del.vm.centos8.yml
 
 test.rpms.centos8: prep.vm.centos8
-	@ansible-playbook --inventory ./ansible/vagrant_ansible_inventory.centosstream8 ./ansible/test.rpms.centos8.yml --extra-vars "refspec=$(refspec)"
+	@ansible-playbook --inventory ./ansible/vagrant_ansible_inventory.centos8s ./ansible/test.rpms.centos8.yml --extra-vars "refspec=$(refspec)"
 
 rpms.centos9:
 	@ansible-playbook --inventory localhost, ./ansible/build.rpms.centos9.yml --extra-vars "refspec=$(refspec)"
@@ -32,7 +32,7 @@ del.vm.centos9:
 	@ansible-playbook --inventory localhost, ./ansible/del.vm.centos9.yml
 
 test.rpms.centos9: prep.vm.centos9
-	@ansible-playbook --inventory ./ansible/vagrant_ansible_inventory.centosstream9 ./ansible/test.rpms.centos9.yml --extra-vars "refspec=$(refspec)"
+	@ansible-playbook --inventory ./ansible/vagrant_ansible_inventory.centos9s ./ansible/test.rpms.centos9.yml --extra-vars "refspec=$(refspec)"
 
 
 vers = 36

--- a/ansible/del.vm.centos8.yml
+++ b/ansible/del.vm.centos8.yml
@@ -5,7 +5,7 @@
   vars_files:
     - vars.yml
   vars:
-    version: "stream8"
+    version: "8s"
     vm: "centos{{ version }}"
   roles:
     - del.vm

--- a/ansible/del.vm.centos9.yml
+++ b/ansible/del.vm.centos9.yml
@@ -5,7 +5,7 @@
   vars_files:
     - vars.yml
   vars:
-    version: "stream9"
+    version: "9s"
     vm: "centos{{ version }}"
   roles:
     - del.vm

--- a/ansible/prep.vm.centos8.yml
+++ b/ansible/prep.vm.centos8.yml
@@ -5,7 +5,7 @@
   vars_files:
     - vars.yml
   vars:
-    version: "stream8"
+    version: "8s"
     vm: "centos{{ version }}"
   roles:
     - prep.vm

--- a/ansible/prep.vm.centos9.yml
+++ b/ansible/prep.vm.centos9.yml
@@ -5,7 +5,7 @@
   vars_files:
     - vars.yml
   vars:
-    version: "stream9"
+    version: "9s"
     vm: "centos{{ version }}"
   roles:
     - prep.vm

--- a/ansible/test.rpms.centos8.yml
+++ b/ansible/test.rpms.centos8.yml
@@ -9,7 +9,7 @@
   roles:
     - set.version
 
-- hosts: centosstream8
+- hosts: centos8s
   become: yes
   become_method: sudo
   vars:

--- a/ansible/test.rpms.centos9.yml
+++ b/ansible/test.rpms.centos9.yml
@@ -9,7 +9,7 @@
   roles:
     - set.version
 
-- hosts: centosstream9
+- hosts: centos9s
   become: yes
   become_method: sudo
   vars:

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby et ts=2 sts=2 sw=2 :
 
 nodes = [
-  { :hostname => "centos" + ENV['VERS'], :box => "centos/" + ENV['VERS'] },
+  { :hostname => "centos" + ENV['VERS'], :box => "generic/centos" + ENV['VERS'] },
   { :hostname => "fedora" + ENV['VERS'], :box => "fedora/" + ENV['VERS'] + "-cloud-base" },
 ]
 


### PR DESCRIPTION
Given the fact that latest versions of vagrant libvirt boxes for CentOS Stream not getting referenced frequently we now switch to generic boxes.