### PR TITLE
Enable AD DC packages on 4.17 and 4.18 release branches for CentOS Stream 9

### DIFF
--- a/packaging/samba-4.17.spec.j2
+++ b/packaging/samba-4.17.spec.j2
@@ -9,8 +9,9 @@
 # ctdb is enabled by default, you can disable it with: --without clustering
 %bcond_without clustering
 
-# Build with Active Directory Domain Controller support by default on Fedora
-%if 0%{?fedora} >= 34
+# Build with Active Directory Domain Controller support by default on Fedora and
+# RHEL >= 9
+%if 0%{?rhel} >= 9 || 0%{?fedora} >= 34
 %bcond_without dc
 %else
 %bcond_with dc
@@ -241,7 +242,7 @@ BuildRequires: perl(Archive::Tar)
 BuildRequires: perl(Test::More)
 BuildRequires: popt-devel
 BuildRequires: python3-devel
-#BuildRequires: python3-dns
+BuildRequires: python3-dns
 #BuildRequires: python3-setuptools
 BuildRequires: quota-devel
 BuildRequires: readline-devel
@@ -476,7 +477,6 @@ Requires: python3-setproctitle
 # See bug 1507420
 %samba_requires_eq libldb
 
-Requires: python3-crypto
 Requires: python3-%{name} = %{samba_depver}
 Requires: python3-%{name}-dc = %{samba_depver}
 Requires: krb5-server >= %{required_mit_krb5}

--- a/packaging/samba-4.18.spec.j2
+++ b/packaging/samba-4.18.spec.j2
@@ -12,8 +12,9 @@
 # Define _make_verbose if it doesn't exist (RHEL8)
 %{!?_make_verbose:%define _make_verbose V=1 VERBOSE=1}
 
-# Build with Active Directory Domain Controller support by default on Fedora
-%if 0%{?fedora} >= 34
+# Build with Active Directory Domain Controller support by default on Fedora and
+# RHEL >= 9
+%if 0%{?rhel} >= 9 || 0%{?fedora} >= 34
 %bcond_without dc
 %else
 %bcond_with dc


### PR DESCRIPTION
Installation test for `samba-dc` package failed on 4.17 and 4.18 release branches as I missed to make changes to corresponding spec files via https://github.com/samba-in-kubernetes/samba-build/commit/70511f0c1ade472b51275442caf1500e97e4d6d9. Therefore make necessary and similar changes to 4.17 and 4.18 spec files.