### PR TITLE
Few cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test.rpms.centos9: prep.vm.centos9
 	@ansible-playbook --inventory ./ansible/vagrant_ansible_inventory.centos9s ./ansible/test.rpms.centos9.yml --extra-vars "refspec=$(refspec)"
 
 
-vers = 36
+vers = 38
 
 rpms.fedora:
 	@ansible-playbook --inventory localhost, ./ansible/build.rpms.fedora.yml --extra-vars "version=$(vers) refspec=$(refspec)"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Samba CentOS/Fedora RPM Builds
 
-[![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora37-master&subject=master / Fedora 37>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora37-master/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora37-v4-16-test&subject=v4-16-test / Fedora 37>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora37-v4-16-test/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora37-v4-17-test&subject=v4-17-test / Fedora 37>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora37-v4-17-test/)
+[![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora37-master&subject=master / Fedora 37>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora37-master/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora37-v4-18-test&subject=v4-18-test / Fedora 37>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora37-v4-18-test/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora37-v4-17-test&subject=v4-17-test / Fedora 37>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora37-v4-17-test/)
 
-[![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora36-master&subject=master / Fedora 36>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora36-master/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora36-v4-16-test&subject=v4-16-test / Fedora 36>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora36-v4-16-test/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora36-v4-17-test&subject=v4-17-test / Fedora 36>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora36-v4-17-test/)
+[![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora38-master&subject=master / Fedora 38>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora38-master/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora38-v4-18-test&subject=v4-18-test / Fedora 38>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora38-v4-18-test/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-fedora38-v4-17-test&subject=v4-17-test / Fedora 38>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-fedora38-v4-17-test/)
 
-[![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos8-master&subject=master / CentOS 8>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos8-master/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos8-v4-16-test&subject=v4-16-test / CentOS 8>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos8-v4-16-test/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos8-v4-17-test&subject=v4-17-test / CentOS 8>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos8-v4-17-test/)
+[![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos8-master&subject=master / CentOS 8>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos8-master/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos8-v4-18-test&subject=v4-18-test / CentOS 8>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos8-v4-18-test/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos8-v4-17-test&subject=v4-17-test / CentOS 8>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos8-v4-17-test/)
 
-[![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos9-master&subject=master / CentOS 9>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos9-master/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos9-v4-16-test&subject=v4-16-test / CentOS 9>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos9-v4-16-test/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos9-v4-17-test&subject=v4-17-test / CentOS 9>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos9-v4-17-test/)
+[![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos9-master&subject=master / CentOS 9>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos9-master/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos9-v4-18-test&subject=v4-18-test / CentOS 9>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos9-v4-18-test/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos9-v4-17-test&subject=v4-17-test / CentOS 9>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos9-v4-17-test/)
 
-This repository contains automation to create RPMs for CentOS 8/9 and Fedora
-from Samba repository. In order to allow building from a variety of git refspecs,
-the following make target format is used:
+This repository contains automation to create RPMs for CentOS Stream 8/9 and
+Fedora from Samba repository. In order to allow building from a variety of git
+refspecs, the following make target format is used:
 
 `$ make < rpms.centos8 | rpms.centos9 | rpms.fedora > [ vers=< fedora-version > refspec=< branch-name | tag-name | h:<git-commit-hash> > ]`
 
@@ -20,16 +20,15 @@ Few examples:
 - `$ make rpms.centos9 refspec=h:a0862d6d6de`
 - `$ make rpms.fedora vers=37 refspec=samba-4.16.4`
 
-As of now 4.16, 4.17 and master branches are supported. In the absence of
+As of now 4.17, 4.18 and master branches are supported. In the absence of
 *refspec* argument, the master branch is built by default. The above format is
 also applicable for other `make` targets. The *vers* argument is only valid for
 Fedora related make targets and in its absence, the default version is
-set to *36*.
+set to *38*.
 
-The RPMs contain the Samba file server pieces, including the glusterfs and
-glusterfs_fuse vfs modules. They do not contain the active directory domain
-controller.
+Except on CentOS Stream 8, in addition to vfs-glusterfs and vfs-cephfs, Active
+Directory Domain Controller components are also built as RPMs.
 
-These are automatically run as nightly jobs for CentOS 8/9 and Fedora 37/36 on
-[centos-ci](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/view/RPMs) and published
-as [yum repositories](https://artifacts.ci.centos.org/samba/pkgs/).
+These are automatically run as nightly jobs for CentOS Stream 8/9 and
+Fedora 37/38 on [centos-ci](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/view/RPMs)
+and published as [yum repositories](https://artifacts.ci.centos.org/samba/pkgs/).

--- a/ansible/roles/prep.dirs/tasks/repo.yml
+++ b/ansible/roles/prep.dirs/tasks/repo.yml
@@ -6,11 +6,6 @@
 
 - name: adapt mock config to use additional template for ceph
   block:
-    - name: install jq
-      yum:
-        name: jq
-        state: latest
-
     - name: determine ceph repo base url
       shell: curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/{{ item }}/x86_64&flavor=default&ref=main&sha1=latest" | jq -r .[0].url
       register: get_ceph_repo_url

--- a/packaging/samba-4.17.spec.j2
+++ b/packaging/samba-4.17.spec.j2
@@ -97,12 +97,6 @@
 #
 # https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/master/f/buildflags.md
 %undefine _strict_symbol_defs_build
-# Disable .package_note file generation, see bug for details
-#
-# https://bugzilla.redhat.com/show_bug.cgi?id=2043178
-%if 0%{?fedora} >= 36
-%undefine _package_note_file
-%endif
 
 %global libwbc_alternatives_version 0.15
 %global libwbc_alternatives_suffix %nil
@@ -251,6 +245,10 @@ BuildRequires: xz
 BuildRequires: zlib-devel >= 1.2.3
 
 BuildRequires: pkgconfig(libsystemd)
+
+%if 0%{?fedora} >= 37
+BuildRequires: mold
+%endif
 
 %if %{with vfs_glusterfs}
 BuildRequires: libgfapi-devel >= 3.4.0.16
@@ -1115,13 +1113,16 @@ Support for using an existing CEPH cluster as a mutex helper for CTDB
 
 %global _samba_private_libraries %{_libsmbclient}%{_libwbclient}
 
-# TODO: resolve underlinked python modules
-export python_LDFLAGS="$(echo %{__global_ldflags} | sed -e 's/-Wl,-z,defs//g')"
-
-%if 0%{?fedora} || 0%{?rhel} < 9
+%if 0%{?fedora} >= 37
+# Use the mold linker
+export LDFLAGS="%{__global_ldflags} -fuse-ld=mold"
+%else
 # Use the gold linker
 export LDFLAGS="%{__global_ldflags} -fuse-ld=gold"
 %endif
+
+# TODO: resolve underlinked python modules
+export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
 
 %configure \
         --enable-fhs \

--- a/packaging/samba-4.18.spec.j2
+++ b/packaging/samba-4.18.spec.j2
@@ -100,12 +100,6 @@
 #
 # https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/master/f/buildflags.md
 %undefine _strict_symbol_defs_build
-# Disable .package_note file generation, see bug for details
-#
-# https://bugzilla.redhat.com/show_bug.cgi?id=2043178
-%if 0%{?fedora} >= 36
-%undefine _package_note_file
-%endif
 
 %global libwbc_alternatives_version 0.16
 %global libwbc_alternatives_suffix %nil
@@ -1173,20 +1167,16 @@ rm -f lib/crypto/{aes,rijndael}*.c
 
 %global _samba_private_libraries %{_libsmbclient}%{_libwbclient}
 
-# TODO: resolve underlinked python modules
-export python_LDFLAGS="$(echo %{__global_ldflags} | sed -e 's/-Wl,-z,defs//g')"
-
-%if 0%{?fedora} || 0%{?rhel} < 9
-# Use the gold linker
-export LDFLAGS="%{__global_ldflags} -fuse-ld=gold"
-export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
-%endif
-
 %if 0%{?fedora} >= 37
 # Use the mold linker
 export LDFLAGS="%{__global_ldflags} -fuse-ld=mold"
-export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
+%else
+# Use the gold linker
+export LDFLAGS="%{__global_ldflags} -fuse-ld=gold"
 %endif
+
+# TODO: resolve underlinked python modules
+export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
 
 %configure \
         --enable-fhs \

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -100,12 +100,6 @@
 #
 # https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/master/f/buildflags.md
 %undefine _strict_symbol_defs_build
-# Disable .package_note file generation, see bug for details
-#
-# https://bugzilla.redhat.com/show_bug.cgi?id=2043178
-%if 0%{?fedora} >= 36
-%undefine _package_note_file
-%endif
 
 %global libwbc_alternatives_version 0.16
 %global libwbc_alternatives_suffix %nil
@@ -1174,20 +1168,16 @@ rm -f lib/crypto/{aes,rijndael}*.c
 
 %global _samba_private_libraries %{_libsmbclient}%{_libwbclient}
 
-# TODO: resolve underlinked python modules
-export python_LDFLAGS="$(echo %{__global_ldflags} | sed -e 's/-Wl,-z,defs//g')"
-
-%if 0%{?fedora} || 0%{?rhel} < 9
-# Use the gold linker
-export LDFLAGS="%{__global_ldflags} -fuse-ld=gold"
-export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
-%endif
-
 %if 0%{?fedora} >= 37
 # Use the mold linker
 export LDFLAGS="%{__global_ldflags} -fuse-ld=mold"
-export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
+%else
+# Use the gold linker
+export LDFLAGS="%{__global_ldflags} -fuse-ld=gold"
 %endif
+
+# TODO: resolve underlinked python modules
+export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
 
 %configure \
         --enable-fhs \


### PR DESCRIPTION
* SPEC file cleanup
  - [bz #2043178](https://bugzilla.redhat.com/show_bug.cgi?id=2043178) is now fixed.
  - _.package_notes_file_ generation works with `ld.gold` on CentOS Stream 9 too.
  - conditionally use `ld.mold` on Fedora 37 and higher.
* Default fedora version to build changed to 38.
* Update README to reflect recent changes.
* Remove `jq` installation task.

depends on #12  #9 https://github.com/samba-in-kubernetes/samba-centosci/pull/16