### PR TITLE
Do not include `libauthn_policy` as separate library

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2050,7 +2050,6 @@ fi
 
 %if %{with dc} || %{with testsuite}
 %{_libdir}/samba/libad-claims-samba4.so
-%{_libdir}/samba/libauthn-policy-samba4.so
 %{_libdir}/samba/libauthn-policy-util-samba4.so
 %{_libdir}/samba/libdb-glue-samba4.so
 %{_libdir}/samba/libpac-samba4.so


### PR DESCRIPTION
libauthn_policy is no longer a separate library but just a subsystem for building other libraries.

See [upstream change](https://git.samba.org/?p=samba.git;a=commit;h=b3a85655825fb6c6a1d668379c1ab004707dc56d) for details.