### PR TITLE
Fix base url for nightly gluster packages

### DIFF
--- a/ansible/roles/prep.dirs/files/glusterfs-nightly-repo.tpl
+++ b/ansible/roles/prep.dirs/files/glusterfs-nightly-repo.tpl
@@ -2,7 +2,7 @@ config_opts['yum.conf'] += """
 
 [gluster-nightly-master]
 name=Gluster Nightly builds (master branch)
-baseurl=http://artifacts.ci.centos.org/gluster/nightly/devel/$releasever-stream/$basearch
+baseurl=http://artifacts.ci.centos.org/gluster/nightly/devel/$releasever/$basearch
 enabled=1
 gpgcheck=0
 """


### PR DESCRIPTION
Changes from https://github.com/gluster/centosci/commit/c23a78c4f43a1febd13d043e8e4408789bb5b6e9 modified the url where nightly built gluster packages were uploaded.