### PR TITLE
Bump minimum krb5 version requirement to 1.21

### DIFF
--- a/ansible/roles/test.rpms.fedora/files/rpm-install.sh
+++ b/ansible/roles/test.rpms.fedora/files/rpm-install.sh
@@ -24,15 +24,19 @@ enabled=1
 gpgcheck=0
 EOF
 
-# Since we do not have nightly GlusterFS packages built for Fedora, we make use
-# of official released versions from standard Fedora repositories
+# Since we do not have GlusterFS(master) and CephFS(main) packages built for
+# Fedora, we make use of official released versions from standard Fedora
+# repositories.
 
 test_build_vers=$(dnf repoquery -q --disablerepo='*' \
 			--enablerepo=samba-${samba_version}-test-rpms \
 			--arch x86_64 --qf '%{version}-%{release}' samba)
 
 pkgs=(samba-${test_build_vers} samba-test-${test_build_vers} \
-	samba-vfs-glusterfs-${test_build_vers} samba-vfs-cephfs-${test_build_vers} \
-	samba-dc-${test_build_vers})
+	samba-vfs-glusterfs-${test_build_vers} samba-vfs-cephfs-${test_build_vers})
+
+if [ "${os_version}" -ge 38 ]; then
+	pkgs+=(samba-dc-${test_build_vers})
+fi
 
 dnf -y install ${pkgs[@]}

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -14,7 +14,7 @@
 
 # Build with Active Directory Domain Controller support by default on Fedora and
 # RHEL >= 9
-%if 0%{?rhel} >= 9 || 0%{?fedora} >= 34
+%if 0%{?rhel} >= 9 || 0%{?fedora} >= 38
 %bcond_without dc
 %else
 %bcond_with dc
@@ -101,7 +101,7 @@
 %endif
 
 %if %{with dc} || %{with testsuite}
-%global required_mit_krb5 1.19
+%global required_mit_krb5 1.21
 %else
 %global required_mit_krb5 1.15.1
 %endif


### PR DESCRIPTION
* Upstream recently [increased](https://git.samba.org/?p=samba.git;a=commit;h=b896da351c8b27440dfb895e866d5a5ce0320b21) minimum krb5 version required to build with AD DC components to 1.21.
  - Considering the timing of this change it means that we need krb5 >= v1.21 for building Samba from v4.20.
* Unlike CentOS Stream 9 we don't expect updated(rebased) krb5 packages on Fedora 37 and lower.
* Adjust rpm-install script accordingly to check for OS version.