### PR TITLE
Include rpcecho server only with selftest

### DIFF
--- a/packaging/samba-4.17.spec.j2
+++ b/packaging/samba-4.17.spec.j2
@@ -2022,7 +2022,9 @@ fi
 %{_libexecdir}/samba/rpcd_fsrvp
 %{_libexecdir}/samba/rpcd_lsad
 %{_libexecdir}/samba/rpcd_mdssvc
+%if %{with testsuite}
 %{_libexecdir}/samba/rpcd_rpcecho
+%endif
 %{_libexecdir}/samba/rpcd_spoolss
 %{_libexecdir}/samba/rpcd_winreg
 %{_libexecdir}/samba/samba-dcerpcd

--- a/packaging/samba-4.18.spec.j2
+++ b/packaging/samba-4.18.spec.j2
@@ -2103,7 +2103,9 @@ fi
 %{_libexecdir}/samba/rpcd_fsrvp
 %{_libexecdir}/samba/rpcd_lsad
 %{_libexecdir}/samba/rpcd_mdssvc
+%if %{with testsuite}
 %{_libexecdir}/samba/rpcd_rpcecho
+%endif
 %{_libexecdir}/samba/rpcd_spoolss
 %{_libexecdir}/samba/rpcd_winreg
 %{_libexecdir}/samba/samba-dcerpcd

--- a/packaging/samba-4.19.spec.j2
+++ b/packaging/samba-4.19.spec.j2
@@ -2107,7 +2107,9 @@ fi
 %{_libexecdir}/samba/rpcd_fsrvp
 %{_libexecdir}/samba/rpcd_lsad
 %{_libexecdir}/samba/rpcd_mdssvc
+%if %{with testsuite}
 %{_libexecdir}/samba/rpcd_rpcecho
+%endif
 %{_libexecdir}/samba/rpcd_spoolss
 %{_libexecdir}/samba/rpcd_winreg
 %{_libexecdir}/samba/samba-dcerpcd

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2107,7 +2107,9 @@ fi
 %{_libexecdir}/samba/rpcd_fsrvp
 %{_libexecdir}/samba/rpcd_lsad
 %{_libexecdir}/samba/rpcd_mdssvc
+%if %{with testsuite}
 %{_libexecdir}/samba/rpcd_rpcecho
+%endif
 %{_libexecdir}/samba/rpcd_spoolss
 %{_libexecdir}/samba/rpcd_winreg
 %{_libexecdir}/samba/samba-dcerpcd


### PR DESCRIPTION
`rpcecho` server is no longer enabled by default as its useful prominently in development and testing. This applies to builds with and without AD DC components.

See [3cf1beed](https://git.samba.org/?p=samba.git;a=commit;h=3cf1beed5df7d8b5d854517de7de322c6a5bc7fa) and [a9c32f92](https://git.samba.org/?p=samba.git;a=commit;h=a9c32f929b7901b4ca230cc7a725b42c8916540d) from upstream.
