### PR TITLE
Use `%autosetup` instead of `%setup`

### DIFF
--- a/packaging/samba-4.18.spec.j2
+++ b/packaging/samba-4.18.spec.j2
@@ -1119,7 +1119,7 @@ Support for using an existing CEPH cluster as a mutex helper for CTDB
 
 %prep
 
-%setup -q -n %{name}-%{version}%{pre_release}
+%autosetup -n %{name}-%{version}%{pre_release} -p1
 
 # Ensure we rely on GnuTLS and do not build any other crypto code shipping with
 # the sources.

--- a/packaging/samba-4.19.spec.j2
+++ b/packaging/samba-4.19.spec.j2
@@ -1120,7 +1120,7 @@ Support for using an existing CEPH cluster as a mutex helper for CTDB
 
 %prep
 
-%setup -q -n %{name}-%{version}%{pre_release}
+%autosetup -n %{name}-%{version}%{pre_release} -p1
 
 # Ensure we rely on GnuTLS and do not build any other crypto code shipping with
 # the sources.

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1120,7 +1120,7 @@ Support for using an existing CEPH cluster as a mutex helper for CTDB
 
 %prep
 
-%setup -q -n %{name}-%{version}%{pre_release}
+%autosetup -n %{name}-%{version}%{pre_release} -p1
 
 # Ensure we rely on GnuTLS and do not build any other crypto code shipping with
 # the sources.


### PR DESCRIPTION
`%autosetup` macro allows taking care of various individual steps needed alongside old `%setup` macro. The most prominent one being the process of applying patches which can be done with just an additional option to `%autosetup` taking away the extra `%patch` step. See [docs](https://rpm-software-management.github.io/rpm/manual/autosetup.html) for more details.