### PR TITLE
New `samba-tool` sub-commands and no more independent LDB

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2164,6 +2164,7 @@ fi
 %{_includedir}/samba-4.0/gen_ndr/security.h
 %{_includedir}/samba-4.0/gen_ndr/server_id.h
 %{_includedir}/samba-4.0/gen_ndr/svcctl.h
+%{_includedir}/samba-4.0/ldb_version.h
 %{_includedir}/samba-4.0/ldb_wrap.h
 %{_includedir}/samba-4.0/lookup_sid.h
 %{_includedir}/samba-4.0/machine_sid.h
@@ -2291,6 +2292,7 @@ fi
 %files ldb-ldap-modules
 %{_libdir}/samba/ldb/ldbsamba_extensions.so
 %{_libdir}/samba/ldb/ildap.so
+%{_libdir}/samba/ldb/ldap.so
 
 ### LIBS
 %files libs

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2444,10 +2444,20 @@ fi
 %dir %{python3_sitearch}/samba/netcmd/domain/claim/__pycache__
 %{python3_sitearch}/samba/netcmd/domain/claim/__pycache__/*.*.pyc
 
+%dir %{python3_sitearch}/samba/netcmd/domain/kds
+%{python3_sitearch}/samba/netcmd/domain/kds/*.py
+%dir %{python3_sitearch}/samba/netcmd/domain/kds/__pycache__
+%{python3_sitearch}/samba/netcmd/domain/kds/__pycache__/*.*.pyc
+
 %dir %{python3_sitearch}/samba/netcmd/domain/models
 %{python3_sitearch}/samba/netcmd/domain/models/*.py
 %dir %{python3_sitearch}/samba/netcmd/domain/models/__pycache__
 %{python3_sitearch}/samba/netcmd/domain/models/__pycache__/*.*.pyc
+
+%dir %{python3_sitearch}/samba/netcmd/service_account
+%{python3_sitearch}/samba/netcmd/service_account/*.py
+%dir %{python3_sitearch}/samba/netcmd/service_account/__pycache__
+%{python3_sitearch}/samba/netcmd/service_account/__pycache__/*.*.pyc
 
 %dir %{python3_sitearch}/samba/netcmd/user
 %{python3_sitearch}/samba/netcmd/user/*.py


### PR DESCRIPTION
* LDB is no longer built independently: see [!3524](https://gitlab.com/samba-team/samba/-/merge_requests/3524)
* New sub-commands to `samba-tool`
  * Handling KDS: see [!3537](https://gitlab.com/samba-team/samba/-/merge_requests/3537)
  * For service accounts: see [!3523](https://gitlab.com/samba-team/samba/-/merge_requests/3523)