### PR TITLE
Add new python modules from policy.py and silo.py

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2452,6 +2452,16 @@ fi
 %dir %{python3_sitearch}/samba/netcmd/domain/auth/__pycache__
 %{python3_sitearch}/samba/netcmd/domain/auth/__pycache__/*.*.pyc
 
+%dir %{python3_sitearch}/samba/netcmd/domain/auth/policy
+%{python3_sitearch}/samba/netcmd/domain/auth/policy/*.py
+%dir %{python3_sitearch}/samba/netcmd/domain/auth/policy/__pycache__
+%{python3_sitearch}/samba/netcmd/domain/auth/policy/__pycache__/*.*.pyc
+
+%dir %{python3_sitearch}/samba/netcmd/domain/auth/silo
+%{python3_sitearch}/samba/netcmd/domain/auth/silo/*.py
+%dir %{python3_sitearch}/samba/netcmd/domain/auth/silo/__pycache__
+%{python3_sitearch}/samba/netcmd/domain/auth/silo/__pycache__/*.*.pyc
+
 %dir %{python3_sitearch}/samba/netcmd/domain/claim
 %{python3_sitearch}/samba/netcmd/domain/claim/*.py
 %dir %{python3_sitearch}/samba/netcmd/domain/claim/__pycache__


### PR DESCRIPTION
Upstream turned following python sources into independent modules:
* _policy.py_ in [c0e748f011](https://git.samba.org/?p=samba.git;a=commit;h=c0e748f0117308d36323001e1cf4387ca6c18297)
* _silo.py_ in [4d2c8ea957](https://git.samba.org/?p=samba.git;a=commit;h=4d2c8ea95783cafcbf954f7bfb040225cb693a68)
