### PR TITLE
Rearrange and package samba-bgqd service components

### DIFF
--- a/packaging/samba-4.20.spec.j2
+++ b/packaging/samba-4.20.spec.j2
@@ -1639,17 +1639,22 @@ fi
 %{_libdir}/samba/vfs/nfs4acl_xattr.so
 %endif
 
+%dir %{_libexecdir}/samba
+%{_libexecdir}/samba/samba-bgqd
+
 %dir %{_datadir}/samba
 %dir %{_datadir}/samba/mdssvc
 %{_datadir}/samba/mdssvc/elasticsearch_mappings.json
 
 %{_unitdir}/nmb.service
+%{_unitdir}/samba-bgqd.service
 %{_unitdir}/smb.service
 %dir %{_sysconfdir}/openldap/schema
 %config %{_sysconfdir}/openldap/schema/samba.schema
 %config(noreplace) %{_sysconfdir}/pam.d/samba
 %{_mandir}/man1/smbstatus.1*
 %{_mandir}/man8/eventlogadm.8*
+%{_mandir}/man8/samba-bgqd.8*
 %{_mandir}/man8/smbd.8*
 %{_mandir}/man8/nmbd.8*
 %{_mandir}/man8/vfs_acl_tdb.8*
@@ -1734,7 +1739,6 @@ fi
 %{_bindir}/wspsearch
 %dir %{_libexecdir}/samba
 %ghost %{_libexecdir}/samba/cups_backend_smb
-%{_libexecdir}/samba/samba-bgqd
 %{_mandir}/man1/dbwrap_tool.1*
 %{_mandir}/man1/nmblookup.1*
 %{_mandir}/man1/oLschema2ldif.1*
@@ -1757,7 +1761,6 @@ fi
 %{_mandir}/man7/traffic_learner.7.*
 %{_mandir}/man7/traffic_replay.7.*
 %{_mandir}/man8/cifsdd.8.*
-%{_mandir}/man8/samba-bgqd.8*
 %{_mandir}/man8/samba-regedit.8*
 %{_mandir}/man8/smbspool.8*
 


### PR DESCRIPTION
upstream [backport](https://git.samba.org/?p=samba.git;a=commit;h=9155d89a2ae04f45d809c46129687c6f5a510a0d) to v4.20 release branch

Moved from samba-client to base package.