### PR TITLE
Remove CTDB sudoers related config and unit test

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2711,7 +2711,6 @@ fi
 %{_sysconfdir}/ctdb/functions
 %{_sysconfdir}/ctdb/nfs-linux-kernel-callout
 %{_sysconfdir}/ctdb/statd-callout
-%config %{_sysconfdir}/sudoers.d/ctdb
 
 # CTDB scripts, no config files
 # script with executable bit means activated
@@ -3325,7 +3324,6 @@ fi
 %{_datadir}/ctdb/tests/UNIT/eventscripts/stubs/ethtool
 %{_datadir}/ctdb/tests/UNIT/eventscripts/stubs/exportfs
 %{_datadir}/ctdb/tests/UNIT/eventscripts/stubs/gstack
-%{_datadir}/ctdb/tests/UNIT/eventscripts/stubs/id
 %{_datadir}/ctdb/tests/UNIT/eventscripts/stubs/ip
 %{_datadir}/ctdb/tests/UNIT/eventscripts/stubs/ip6tables
 %{_datadir}/ctdb/tests/UNIT/eventscripts/stubs/iptables


### PR DESCRIPTION
Upstream recently [removed](https://git.samba.org/?p=samba.git;a=commit;h=991d21d075c0382b27dc9da64e8a6cfd94f175c0) a old hack related to CTDB sudoers config.