### PR TITLE
Include ceph_snapshots VFS module within base package

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1589,6 +1589,9 @@ fi
 %{_libdir}/samba/vfs/btrfs.so
 %{_libdir}/samba/vfs/cap.so
 %{_libdir}/samba/vfs/catia.so
+%if %{with vfs_cephfs}
+%{_libdir}/samba/vfs/ceph_snapshots.so
+%endif
 %{_libdir}/samba/vfs/commit.so
 %{_libdir}/samba/vfs/crossrename.so
 %{_libdir}/samba/vfs/default_quota.so
@@ -1655,6 +1658,9 @@ fi
 %{_mandir}/man8/vfs_btrfs.8*
 %{_mandir}/man8/vfs_cap.8*
 %{_mandir}/man8/vfs_catia.8*
+%if %{with vfs_cephfs}
+%{_mandir}/man8/vfs_ceph_snapshots.8*
+%endif
 %{_mandir}/man8/vfs_commit.8*
 %{_mandir}/man8/vfs_crossrename.8*
 %{_mandir}/man8/vfs_default_quota.8*
@@ -2229,9 +2235,7 @@ fi
 %if %{with vfs_cephfs}
 %files vfs-cephfs
 %{_libdir}/samba/vfs/ceph.so
-%{_libdir}/samba/vfs/ceph_snapshots.so
 %{_mandir}/man8/vfs_ceph.8*
-%{_mandir}/man8/vfs_ceph_snapshots.8*
 %endif
 
 ### VFS-IOURING


### PR DESCRIPTION
Unlike _vfs_ceph_, _vfs_ceph_snapshots_ is an independent module that can be stacked atop ceph kclient. So move it to the base package containing other vfs modules instead of shipping it inside `samba-vfs-cephfs`.

_Originally posted by @Shwetha-Acharya in https://github.com/samba-in-kubernetes/sit-environment/pull/105#discussion_r1656846777_