### PR TITLE
Add support for RHEL builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ test.rpms.centos:
 rpms.rhel:
 	@ansible-playbook --inventory localhost, ./ansible/build.rpms.rhel.yml --extra-vars "$(EXTRA_VARS)"
 
+test.rpms.rhel:
+	@ansible-playbook --inventory localhost, ./ansible/test.rpms.rhel.yml --extra-vars "$(EXTRA_VARS)"
+
 
 rpms.fedora:
 	@ansible-playbook --inventory localhost, ./ansible/build.rpms.fedora.yml --extra-vars "$(EXTRA_VARS)"

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ test.rpms.centos:
 	@ansible-playbook --inventory localhost, ./ansible/test.rpms.centos.yml --extra-vars "$(EXTRA_VARS)"
 
 
+rpms.rhel:
+	@ansible-playbook --inventory localhost, ./ansible/build.rpms.rhel.yml --extra-vars "$(EXTRA_VARS)"
+
+
 rpms.fedora:
 	@ansible-playbook --inventory localhost, ./ansible/build.rpms.fedora.yml --extra-vars "$(EXTRA_VARS)"
 

--- a/README.md
+++ b/README.md
@@ -8,29 +8,41 @@
 
 [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos9-master&subject=master / CentOS 9>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos9-master/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos9-v4-19-test&subject=v4-19-test / CentOS 9>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos9-v4-19-test/) [![status](<https://jenkins-samba.apps.ocp.cloud.ci.centos.org/buildStatus/icon?job=samba_build-rpms-centos9-v4-20-test&subject=v4-20-test / CentOS 9>)](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_build-rpms-centos9-v4-20-test/)
 
-This repository contains automation to create [Samba](https://www.samba.org/) RPMs for CentOS Stream 8/9 and
-Fedora from the upstream  [code repository](https://git.samba.org/samba.git). In order to allow building from a variety of git
-refspecs, the following make target format is used:
+This repository contains automation to create [Samba](https://www.samba.org/)
+RPMs for CentOS Stream 8/9, RHEL and Fedora from the upstream  [code repository](https://git.samba.org/samba.git).
+In order to allow building from a variety of git refspecs, the following make
+target format is used:
 
-`$ make < rpms.centos8 | rpms.centos9 | rpms.fedora > [ vers=< fedora-version > refspec=< branch-name | tag-name | h:<git-commit-hash> > ]`
+`$ make < rpms.centos | rpms.fedora | rpms.rhel > [ vers=< os-version > refspec=< branch-name | tag-name | h:<git-commit-hash> > ]`
 
 A Few examples:
 
 ```console
-$ make rpms.centos8 refspec=v4-20-test
-$ make rpms.centos9 refspec=h:a0862d6d6de
+$ make rpms.centos refspec=v4-20-test
 $ make rpms.fedora vers=39 refspec=samba-4.19.6
+$ make rpms.rhel refspec=h:a0862d6d6de
 ```
 
-As of now, versions  4.19 and  4.20 and the master branch are supported. In the absence of the 
-*refspec* argument the master branch is built by default. The above format is
-also applicable for other `make` targets. The *vers* argument is only valid for
-Fedora related make targets and specifies the Fedora version to build for. In its absence the default version is
-set to *40*.
+As of now, versions  4.19 and  4.20 and the master branch are supported. In the
+absence of the *refspec* argument the master branch is built by default. The
+above format is also applicable for other `make` targets. In the absence of
+*vers* argument *9* and *40* will be the default for RHEL/CentOS and Fedora
+respectively.
 
-Except on CentOS Stream 8, in addition to vfs-glusterfs and vfs-cephfs, Active
-Directory Domain Controller components are also built as RPMs.
+Except on CentOS Stream 8 and RHEL, in addition to vfs-glusterfs and vfs-cephfs,
+Active Directory Domain Controller components are also built as RPMs.
 
 These are automatically run as nightly jobs for CentOS Stream 8/9 and
 Fedora 39/40 on [centos-ci](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/view/RPM)
 and published as [yum repositories](https://artifacts.ci.centos.org/samba/pkgs/).
+
+### Building for RHEL
+In order to match one-to-one with the dependencies from RHEL repositories we
+have the following two options:
+
+- Register the host running the build targets to ensure that mock has access to
+mandatorily required RHEL repositories(BaseOS, AppStream and CodeReadyBuilder)
+- If you want to leave the host as it is, use `ORG_ID` and `ACT_KEY` environment
+variables to perform the build operation via podman containers where `ORG_ID` is
+the organizational ID and `ACT_KEY` is the activation key name used for
+registration purposes within container.

--- a/ansible/build.rpms.rhel.yml
+++ b/ansible/build.rpms.rhel.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  connection: local
+  become: no
+  vars:
+    refspec: "{{ refspec }}"
+    os_vers: "{{ version | default('9') }}"
+    org_id: "{{ lookup('env', 'ORG_ID', default=Undefined) }}"
+    act_key: "{{ lookup('env', 'ACT_KEY', default=Undefined) }}"
+  vars_files:
+    - vars.yml
+  roles:
+    - prep.dirs
+    - set.version
+    - make.tarball
+    - make.srpm
+    - build.rpms.rhel

--- a/ansible/roles/build.rpms.rhel/files/rpm-build.sh
+++ b/ansible/roles/build.rpms.rhel/files/rpm-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+subscription-manager register --org "${ORG_ID}" --activationkey "${ACT_KEY}"
+
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERS}.noarch.rpm
+
+dnf -y install mock rpm-build
+
+mock --root "${MOCK_DIR}/rhel-${OS_VERS}-x86_64.cfg" --resultdir "${RPMS_DIR}/${SAMBA_VERS}/rhel/${OS_VERS}/x86_64" --rebuild "${SRPM_DIR}/${SAMBA_SRPM}"
+
+subscription-manager unregister

--- a/ansible/roles/build.rpms.rhel/tasks/main.yml
+++ b/ansible/roles/build.rpms.rhel/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Build rhel {{ os_vers }} rpms locally
+  when: org_id is undefined or act_key is undefined
+  command: /usr/bin/mock --root {{ mock_dir }}/rhel-{{ os_vers }}-x86_64.cfg --resultdir {{ rpms_dir }}/{{ samba_major_version }}/rhel/{{ os_vers }}/x86_64 --rebuild {{ srpm_dir }}/{{ samba_srpm }}
+
+- name: Build rhel {{ os_vers }} rpms in a container
+  when: org_id is defined and act_key is defined
+  containers.podman.podman_container:
+    name: "rhel_samba_build"
+    image: "registry.access.redhat.com/ubi{{ os_vers }}"
+    privileged: true
+    command: /tmp/files/rpm-build.sh
+    detach: false
+    rm: true
+    volume:
+      - "{{ role_path }}/files:/tmp/files:z"
+      - "{{ build_dir }}:{{ build_dir }}:z"
+    env:
+      ORG_ID: "{{ org_id }}"
+      ACT_KEY: "{{ act_key }}"
+      OS_VERS: "{{ os_vers }}"
+      MOCK_DIR: "{{ mock_dir }}"
+      SRPM_DIR: "{{ srpm_dir }}"
+      RPMS_DIR: "{{ rpms_dir }}"
+      SAMBA_SRPM: "{{ samba_srpm }}"
+      SAMBA_VERS: "{{ samba_major_version }}"

--- a/ansible/roles/prep.dirs/files/epel-restricted.tpl
+++ b/ansible/roles/prep.dirs/files/epel-restricted.tpl
@@ -1,0 +1,10 @@
+config_opts['dnf.conf'] += """
+
+[epel]
+name=Extra Packages for Enterprise Linux $releasever - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+includepkgs=thrift
+"""

--- a/ansible/roles/prep.dirs/tasks/main.yml
+++ b/ansible/roles/prep.dirs/tasks/main.yml
@@ -35,9 +35,12 @@
   loop:
     - /etc/mock/centos-stream+epel-next-8-x86_64.cfg
     - /etc/mock/centos-stream+epel-next-9-x86_64.cfg
+    - /etc/mock/rhel-8-x86_64.cfg
+    - /etc/mock/rhel-9-x86_64.cfg
     - glusterfs-nightly-repo.tpl
     - ceph-el8-dev-repo.tpl.j2
     - ceph-el9-dev-repo.tpl.j2
+    - epel-restricted.tpl
 
 - name: copy fedora mock config files
   copy:

--- a/ansible/roles/prep.dirs/tasks/repo.yml
+++ b/ansible/roles/prep.dirs/tasks/repo.yml
@@ -1,8 +1,13 @@
 - name: adapt mock config to use additional template for glusterfs
   lineinfile:
-    path: "{{ mock_dir }}/centos-stream+epel-next-{{ item }}-x86_64.cfg"
+    path: "{{ mock_config }}"
     insertafter: EOF
     line: "include('{{ mock_dir }}/glusterfs-nightly-repo.tpl')"
+  with_items:
+    - "{{ mock_dir }}/centos-stream+epel-next-{{ item }}-x86_64.cfg"
+    - "{{ mock_dir }}/rhel-{{ item }}-x86_64.cfg"
+  loop_control:
+    loop_var: mock_config
 
 - name: adapt mock config to use additional template for ceph
   block:
@@ -20,6 +25,17 @@
 
     - name: add to mock config
       lineinfile:
-        path: "{{ mock_dir }}/centos-stream+epel-next-{{ item }}-x86_64.cfg"
+        path: "{{ mock_config }}"
         insertafter: EOF
         line: "include('{{ mock_dir }}/ceph-el{{ item }}-dev-repo.tpl')"
+      with_items:
+        - "{{ mock_dir }}/centos-stream+epel-next-{{ item }}-x86_64.cfg"
+        - "{{ mock_dir }}/rhel-{{ item }}-x86_64.cfg"
+      loop_control:
+        loop_var: mock_config
+
+- name: adapt mock config to use limited packages from epel for rhel
+  lineinfile:
+    path: "{{ mock_dir }}/rhel-{{ item }}-x86_64.cfg"
+    insertafter:  EOF
+    line: "include('{{ mock_dir }}/epel-restricted.tpl')"

--- a/ansible/roles/test.rpms.rhel/files/rpm-install.sh
+++ b/ansible/roles/test.rpms.rhel/files/rpm-install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+os_version=${OS_VERS:-"8"}
+samba_version=${SAMBA_VERS:-"master"}
+rpms_dir="/tmp/testbuild/${samba_version}/rhel/${os_version}/x86_64"
+
+subscription-manager register --org "${ORG_ID}" --activationkey "${ACT_KEY}"
+
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${os_version}.noarch.rpm
+
+dnf -y install createrepo_c
+
+pushd "${rpms_dir}"
+
+createrepo_c .
+
+popd
+
+cat > "/etc/yum.repos.d/samba-${samba_version}-test-rpms.repo" <<EOF
+[samba-${samba_version}-test-rpms]
+name=Samba ${samba_version} test rpms repository
+baseurl=file:///tmp/testbuild/${samba_version}/rhel/\$releasever/\$basearch
+enabled=1
+gpgcheck=0
+EOF
+
+dnf -y install --nogpgcheck \
+	${CEPH_RELEASE_RPM_BASE_URL}/noarch/ceph-release-1-0.el${os_version}.noarch.rpm
+
+test_build_vers=$(dnf repoquery -q --disablerepo='*' \
+			--enablerepo=samba-${samba_version}-test-rpms \
+			--arch x86_64 --qf '%{version}-%{release}' samba)
+
+dnf -y --setopt epel.includepkgs=thrift install samba-${test_build_vers} \
+	samba-test-${test_build_vers} samba-vfs-cephfs-${test_build_vers}
+
+subscription-manager unregister

--- a/ansible/roles/test.rpms.rhel/tasks/main.yml
+++ b/ansible/roles/test.rpms.rhel/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Test installation of built rhel {{ os_vers }} rpms in a container
+  containers.podman.podman_container:
+    name: "rhel_samba_build_test"
+    image: "registry.access.redhat.com/ubi{{ os_vers }}"
+    privileged: true
+    command: /tmp/files/rpm-install.sh
+    detach: false
+    rm: true
+    volume:
+      - "{{ role_path }}/files/:/tmp/files/:z"
+      - "{{ rpms_dir }}:/tmp/testbuild/:z"
+    env:
+      OS_VERS: "{{ os_vers }}"
+      SAMBA_VERS: "{{ samba_major_version }}"
+      ORG_ID: "{{ lookup('env', 'ORG_ID') }}"
+      ACT_KEY: "{{ lookup('env', 'ACT_KEY') }}"
+      CEPH_RELEASE_RPM_BASE_URL: "{{ lookup('vars', 'ceph_el' ~ os_vers ~ '_repo_base_url') }}"

--- a/ansible/test.rpms.rhel.yml
+++ b/ansible/test.rpms.rhel.yml
@@ -1,0 +1,12 @@
+- hosts: localhost
+  connection: local
+  become: no
+  vars:
+    refspec: "{{ refspec }}"
+    os_vers: "{{ version | default('9') }}"
+  vars_files:
+    - vars.yml
+  roles:
+    - prep.dirs
+    - set.version
+    - test.rpms.rhel

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -13,8 +13,8 @@
 %{!?_make_verbose:%define _make_verbose V=1 VERBOSE=1}
 
 # Build with Active Directory Domain Controller support by default on Fedora and
-# RHEL >= 9
-%if 0%{?rhel} >= 9 || 0%{?fedora} >= 38
+# CentOS
+%if (0%{?rhel} >= 9 && 0%{?centos}) || 0%{?fedora} >= 38
 %bcond_without dc
 %else
 %bcond_with dc

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -50,11 +50,11 @@
 #endifarch
 %endif
 
-%ifarch aarch64 ppc64le s390x x86_64
-%bcond_without vfs_glusterfs
-%else
 %bcond_with vfs_glusterfs
-#endifarch
+%ifarch aarch64 ppc64le s390x x86_64
+%if (0%{?rhel} && 0%{?centos}) || 0%{?fedora}
+%bcond_without vfs_glusterfs
+%endif
 %endif
 
 # Build the ctdb-pcp-pmda package by default on Fedora


### PR DESCRIPTION
Few considerations from the approach used here:
- In order to satisfy the dependency for _libthrift_ from ceph we restrictively enable EPEL during build and installation testing process.
- Unless you build rhel rpms on a registered system, following environment variables are expected to be present in the execution environment for registration purposes in a podman container:
  - `ORG_ID` : ID to register with one of multiple organizations
  - `ACT_KEY`: activation key name to use for registration
  > NOTE: In the absence of any of these variables it is assumed that the build is attempted on a registered system resulting in rpms being built locally using mock.

fixes #47 
depends on #50 