### PR TITLE
rpmspec: Conditionally exclude ceph manual pages

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1698,11 +1698,9 @@ fi
 %exclude %{_mandir}/man8/vfs_glusterfs.8*
 %endif
 
-%if 0
 %if %{without vfs_cephfs}
 %exclude %{_mandir}/man8/vfs_ceph.8*
 %exclude %{_mandir}/man8/vfs_ceph_snapshots.8*
-%endif
 %endif
 
 %attr(775,root,printadmin) %dir /var/lib/samba/drivers


### PR DESCRIPTION
* Exclude `vfs_ceph` man page for builds without _libcephfs_ support.
* Even though `vfs_ceph_snapshots` doesn't require _libcephfs_, it is only built when `vfs_ceph` is enabled. Accordingly exclude the corresponding man page if the module itself is not present.