### PR TITLE
rpmspec: Fix mispackaging of ldb_version.h

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2158,7 +2158,6 @@ fi
 %{_includedir}/samba-4.0/gen_ndr/security.h
 %{_includedir}/samba-4.0/gen_ndr/server_id.h
 %{_includedir}/samba-4.0/gen_ndr/svcctl.h
-%{_includedir}/samba-4.0/ldb_version.h
 %{_includedir}/samba-4.0/ldb_wrap.h
 %{_includedir}/samba-4.0/lookup_sid.h
 %{_includedir}/samba-4.0/machine_sid.h


### PR DESCRIPTION
For not so long _ldb_version.h_ was incorrectly installed even when it was built as private. This was fixed recently in [upstream](https://git.samba.org/?p=samba.git;a=commit;h=5851ae555425ea2ba8e431162142ebae47be802e) to only install when explicitly not mentioned in the list of bundled libraries.