### PR TITLE
rpmspec: Backport ceph related changes to 4.20

### DIFF
--- a/packaging/samba-4.20.spec.j2
+++ b/packaging/samba-4.20.spec.j2
@@ -1599,6 +1599,9 @@ fi
 %{_libdir}/samba/vfs/btrfs.so
 %{_libdir}/samba/vfs/cap.so
 %{_libdir}/samba/vfs/catia.so
+%if %{with vfs_cephfs}
+%{_libdir}/samba/vfs/ceph_snapshots.so
+%endif
 %{_libdir}/samba/vfs/commit.so
 %{_libdir}/samba/vfs/crossrename.so
 %{_libdir}/samba/vfs/default_quota.so
@@ -1665,6 +1668,9 @@ fi
 %{_mandir}/man8/vfs_btrfs.8*
 %{_mandir}/man8/vfs_cap.8*
 %{_mandir}/man8/vfs_catia.8*
+%if %{with vfs_cephfs}
+%{_mandir}/man8/vfs_ceph_snapshots.8*
+%endif
 %{_mandir}/man8/vfs_commit.8*
 %{_mandir}/man8/vfs_crossrename.8*
 %{_mandir}/man8/vfs_default_quota.8*
@@ -1702,11 +1708,10 @@ fi
 %exclude %{_mandir}/man8/vfs_glusterfs.8*
 %endif
 
-%if 0
 %if %{without vfs_cephfs}
 %exclude %{_mandir}/man8/vfs_ceph.8*
+%exclude %{_mandir}/man8/vfs_ceph_new.8*
 %exclude %{_mandir}/man8/vfs_ceph_snapshots.8*
-%endif
 %endif
 
 %attr(775,root,printadmin) %dir /var/lib/samba/drivers
@@ -2259,9 +2264,9 @@ fi
 %if %{with vfs_cephfs}
 %files vfs-cephfs
 %{_libdir}/samba/vfs/ceph.so
-%{_libdir}/samba/vfs/ceph_snapshots.so
+%{_libdir}/samba/vfs/ceph_new.so
 %{_mandir}/man8/vfs_ceph.8*
-%{_mandir}/man8/vfs_ceph_snapshots.8*
+%{_mandir}/man8/vfs_ceph_new.8*
 %endif
 
 ### VFS-IOURING


### PR DESCRIPTION
* New ceph vfs module is now available with v4-20-test. See [bug #15686](https://bugzilla.samba.org/show_bug.cgi?id=15686) for more details.
* Backport following ceph related changes from master spec file:
    - 77450fe9bfb4cf8a578e75e1ebd09f1d28c305e0
    - 37e864654244c092be3b9ac625db7cfbf84abd80