### PR TITLE
rpmspec: Sync recent CTDB changes

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2672,6 +2672,7 @@ fi
 %config(noreplace) %{_sysconfdir}/ctdb/ctdb.conf
 %config(noreplace) %{_sysconfdir}/ctdb/notify.sh
 %config(noreplace) %{_sysconfdir}/ctdb/debug-hung-script.sh
+%config(noreplace) %{_sysconfdir}/ctdb/ctdb-backup-persistent-tdbs.sh
 %config(noreplace) %{_sysconfdir}/ctdb/ctdb-crash-cleanup.sh
 %config(noreplace) %{_sysconfdir}/ctdb/debug_locks.sh
 
@@ -2715,8 +2716,8 @@ fi
 %{_libexecdir}/ctdb/ctdb_natgw
 %{_libexecdir}/ctdb/ctdb-path
 %{_libexecdir}/ctdb/ctdb_recovery_helper
+%{_libexecdir}/ctdb/ctdb_smnotify_helper
 %{_libexecdir}/ctdb/ctdb_takeover_helper
-%{_libexecdir}/ctdb/smnotify
 %{_libexecdir}/ctdb/statd_callout
 %{_libexecdir}/ctdb/statd_callout_helper
 %{_libexecdir}/ctdb/tdb_mutex_check
@@ -2765,6 +2766,7 @@ fi
 %{_datadir}/ctdb/events/legacy/60.nfs.script
 %{_datadir}/ctdb/events/legacy/70.iscsi.script
 %{_datadir}/ctdb/events/legacy/91.lvs.script
+%{_datadir}/ctdb/events/legacy/95.database.script
 %dir %{_datadir}/ctdb/scripts
 %{_datadir}/ctdb/scripts/winbind_ctdb_updatekeytab.sh
 


### PR DESCRIPTION
* CTDB's native smnotify got removed in favour of similar one from nfs-util. [!3721](https://gitlab.com/samba-team/samba/-/merge_requests/3721)
* Support for persistent TDB backups. [!3764](https://gitlab.com/samba-team/samba/-/merge_requests/3764)