### PR TITLE
prep.dirs: Fix `if` condition in ceph repo template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ rpms.fedora:
 	@ansible-playbook --inventory localhost, ./ansible/build.rpms.fedora.yml --skip-tags repos --extra-vars "$(EXTRA_VARS)"
 
 test.rpms.fedora:
-	@ansible-playbook --inventory localhost, ./ansible/test.rpms.fedora.yml ---skip-tags repos -extra-vars "$(EXTRA_VARS)"
+	@ansible-playbook --inventory localhost, ./ansible/test.rpms.fedora.yml --skip-tags repos --extra-vars "$(EXTRA_VARS)"

--- a/ansible/roles/prep.dirs/files/ceph-repo.tpl.j2
+++ b/ansible/roles/prep.dirs/files/ceph-repo.tpl.j2
@@ -4,7 +4,7 @@ config_opts['yum.conf'] += """
 name = Ceph builds
 baseurl={{ ceph_repo_base_url }}/x86_64
 enabled = 1
-{% if ceph_repo_gpgkey %}
+{% if ceph_repo_gpgkey is defined %}
 gpgcheck = 1
 gpgkey = {{ ceph_repo_gpgkey }}
 {% else %}


### PR DESCRIPTION
- `ceph_repo_gpgkey` in its absence is an undefined variable. Therefore explicitly check whether it is defined or not.
- Fix misplacement of hyphen(`-`) in Makefile.