### PR TITLE
rpmspec: Include always built mdb.so

### DIFF
--- a/packaging/samba-4.21.spec.j2
+++ b/packaging/samba-4.21.spec.j2
@@ -209,9 +209,7 @@ BuildRequires: libcmocka-devel
 BuildRequires: libtirpc-devel
 BuildRequires: libuuid-devel
 BuildRequires: libxslt
-%if %{with dc} || %{with testsuite}
 BuildRequires: lmdb
-%endif
 %if %{with winexe}
 BuildRequires: mingw32-gcc
 BuildRequires: mingw64-gcc
@@ -1897,9 +1895,7 @@ fi
 
 %{_libdir}/samba/ldb/asq.so
 %{_libdir}/samba/ldb/ldb.so
-%if %{with dc} || %{with testsuite}
 %{_libdir}/samba/ldb/mdb.so
-%endif
 %{_libdir}/samba/ldb/paged_searches.so
 %{_libdir}/samba/ldb/rdn_name.so
 %{_libdir}/samba/ldb/sample.so

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -209,9 +209,7 @@ BuildRequires: libcmocka-devel
 BuildRequires: libtirpc-devel
 BuildRequires: libuuid-devel
 BuildRequires: libxslt
-%if %{with dc} || %{with testsuite}
 BuildRequires: lmdb
-%endif
 %if %{with winexe}
 BuildRequires: mingw32-gcc
 BuildRequires: mingw64-gcc
@@ -1890,9 +1888,7 @@ fi
 
 %{_libdir}/samba/ldb/asq.so
 %{_libdir}/samba/ldb/ldb.so
-%if %{with dc} || %{with testsuite}
 %{_libdir}/samba/ldb/mdb.so
-%endif
 %{_libdir}/samba/ldb/paged_searches.so
 %{_libdir}/samba/ldb/rdn_name.so
 %{_libdir}/samba/ldb/sample.so


### PR DESCRIPTION
_mdb_ backend for _ldb_ is now [built](https://gitlab.com/samba-team/samba/-/merge_requests/3807) irrespective of whether AD DC components are enabled or not. Therefore remove the conditional for including _mdb.so_ library.

Since our RPM jobs always build with AD DC this went unnoticed until RHEL builds were attempted where AD DC bits are excluded.

The underlying change is now available with 4.21 release series.