### PR TITLE
Add new crypt wrapper library(backport to 4.21)

### DIFF
--- a/packaging/samba-4.21.spec.j2
+++ b/packaging/samba-4.21.spec.j2
@@ -1865,6 +1865,7 @@ fi
 %{_libdir}/samba/libsocket-blocking-private-samba.so
 %{_libdir}/samba/libtime-basic-private-samba.so
 %{_libdir}/samba/libtorture-private-samba.so
+%{_libdir}/samba/libutil-crypt-private-samba.so
 %{_libdir}/samba/libutil-reg-private-samba.so
 %{_libdir}/samba/libutil-setid-private-samba.so
 %{_libdir}/samba/libutil-tdb-private-samba.so


### PR DESCRIPTION
upstream [backport](https://git.samba.org/?p=samba.git;a=commit;h=0dccda38f27b3bbda5d2a4de588a333ff554651a) to v4-21-stable branch.

Previously #68 added it to the master spec file.