### PR TITLE
rpmspec: Remove the exclude for prometheus endpoint man page

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1706,10 +1706,6 @@ fi
 %exclude %{_mandir}/man8/vfs_ceph_snapshots.8*
 %endif
 
-%if %{without prometheus_endpoint}
-%exclude %{_mandir}/man8/smb_prometheus_endpoint.8*
-%endif
-
 %attr(775,root,printadmin) %dir /var/lib/samba/drivers
 
 ### CLIENT


### PR DESCRIPTION
Previously the man page for smb prometheus endpoint was always built irrespective of the configure option `--with-prometheus-exporter`. This is now fixed in upstream to only build/install when required configure option is specified.

ref: [4c946acb](https://git.samba.org/?p=samba.git;a=commit;h=4c946acb40d616cacbee02bbdb195b629f7f5cd3)