### PR TITLE
Remove non-existing smb_transport library

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1874,7 +1874,6 @@ fi
 %{_libdir}/samba/libsecrets3-private-samba.so
 %{_libdir}/samba/libserver-id-db-private-samba.so
 %{_libdir}/samba/libserver-role-private-samba.so
-%{_libdir}/samba/libsmb-transport-private-samba.so
 %{_libdir}/samba/libsmbclient-raw-private-samba.so
 %{_libdir}/samba/libsmbd-base-private-samba.so
 %{_libdir}/samba/libsmbd-shim-private-samba.so


### PR DESCRIPTION
smb_transport library got merged into cli_smb_common.

ref: [4262b8a](https://git.samba.org/?p=samba.git;a=commit;h=4262b8a809f3e7918abefd7af6d17aa8dc90133d)