### PR TITLE
Add new third_party libraries for SMB over QUIC

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1852,10 +1852,13 @@ fi
 %{_libdir}/samba/libndr-samba4-private-samba.so
 %{_libdir}/samba/libnet-keytab-private-samba.so
 %{_libdir}/samba/libnetif-private-samba.so
+%{_libdir}/samba/libngtcp2-private-samba.so
+%{_libdir}/samba/libngtcp2-crypto-gnutls-private-samba.so
 %{_libdir}/samba/libnpa-tstream-private-samba.so
 %{_libdir}/samba/libposix-eadb-private-samba.so
 %{_libdir}/samba/libprinter-driver-private-samba.so
 %{_libdir}/samba/libprinting-migrate-private-samba.so
+%{_libdir}/samba/libquic-private-samba.so
 %{_libdir}/samba/libreplace-private-samba.so
 %{_libdir}/samba/libregistry-private-samba.so
 %{_libdir}/samba/libsamba-cluster-support-private-samba.so


### PR DESCRIPTION
These are created based on sources from the following repositories:
- https://github.com/lxin/quic
- https://github.com/ngtcp2/ngtcp2

Since the kernel implementation is still not merged there's also a wrapper which is only built when configured with `--enable-selftest`. For now it is ignored as the wrapper may finally end up in its own repository than Samba in the near future.

ref: [!4019](https://gitlab.com/samba-team/samba/-/merge_requests/4019)