### PR TITLE
rpmspec: Build samba-vfs-glusterfs on aarch64

### DIFF
--- a/ansible/roles/prep.dirs/files/glusterfs-nightly-repo.tpl
+++ b/ansible/roles/prep.dirs/files/glusterfs-nightly-repo.tpl
@@ -1,8 +1,0 @@
-config_opts['yum.conf'] += """
-
-[gluster-nightly-master]
-name=Gluster Nightly builds (master branch)
-baseurl=http://artifacts.ci.centos.org/gluster/nightly/devel/$releasever/$basearch
-enabled=1
-gpgcheck=0
-"""

--- a/ansible/roles/prep.dirs/files/sig-storage-gluster.tpl
+++ b/ansible/roles/prep.dirs/files/sig-storage-gluster.tpl
@@ -1,0 +1,9 @@
+config_opts['yum.conf'] += """
+
+[centos-gluster11]
+name=CentOS-$releasever-stream - Gluster 11
+metalink=https://mirrors.centos.org/metalink?repo=centos-storage-sig-gluster-11-$releasever-stream&arch=$basearch
+#baseurl=http://mirror.stream.centos.org/SIGs/$releasever-stream/storage/$basearch/gluster-11/
+gpgcheck=0
+enabled=1
+"""

--- a/ansible/roles/prep.dirs/tasks/main.yml
+++ b/ansible/roles/prep.dirs/tasks/main.yml
@@ -37,7 +37,7 @@
     - /etc/mock/centos-stream+epel-next-9-{{ os_arch }}.cfg
     - /etc/mock/rhel-8-{{ os_arch }}.cfg
     - /etc/mock/rhel-9-{{ os_arch }}.cfg
-    - glusterfs-nightly-repo.tpl
+    - sig-storage-gluster.tpl
     - ceph-repo.tpl.j2
     - epel-restricted.tpl
 

--- a/ansible/roles/prep.dirs/tasks/repo.yml
+++ b/ansible/roles/prep.dirs/tasks/repo.yml
@@ -2,13 +2,12 @@
   lineinfile:
     path: "{{ mock_config }}"
     insertafter: EOF
-    line: "include('{{ mock_dir }}/glusterfs-nightly-repo.tpl')"
+    line: "include('{{ mock_dir }}/sig-storage-gluster.tpl')"
   with_items:
     - "{{ mock_dir }}/centos-stream+epel-next-{{ os_vers }}-{{ os_arch }}.cfg"
     - "{{ mock_dir }}/rhel-{{ os_vers }}-{{ os_arch }}.cfg"
   loop_control:
     loop_var: mock_config
-  when: os_arch == 'x86_64'
 
 - name: adapt mock config to use additional template for ceph
   block:

--- a/ansible/roles/test.rpms.centos/files/rpm-install.sh
+++ b/ansible/roles/test.rpms.centos/files/rpm-install.sh
@@ -39,13 +39,9 @@ test_build_vers=$(dnf repoquery -q --disablerepo='*' \
 dnf_args=()
 
 pkgs=(samba-${test_build_vers} samba-test-${test_build_vers} \
-	samba-vfs-cephfs-${test_build_vers})
+	samba-vfs-cephfs-${test_build_vers} samba-vfs-glusterfs-${test_build_vers})
 
-if [ "${os_arch}" == "x86_64" ]; then
-	dnf config-manager \
-		--add-repo http://artifacts.ci.centos.org/gluster/nightly/master.repo
-	pkgs+=(samba-vfs-glusterfs-${test_build_vers})
-fi
+dnf -y install centos-release-gluster
 
 if [ "${os_version}" == "9" ]; then
 	dnf_args+=(--enablerepo=crb)

--- a/packaging/samba-4.21.spec.j2
+++ b/packaging/samba-4.21.spec.j2
@@ -50,11 +50,12 @@
 #endifarch
 %endif
 
-%bcond_with vfs_glusterfs
-%ifarch ppc64le s390x x86_64
-%if (0%{?rhel} && 0%{?centos}) || 0%{?fedora}
+# Build vfs_glusterfs module by default
+%ifarch aarch64 ppc64le s390x x86_64
 %bcond_without vfs_glusterfs
-%endif
+%else
+%bcond_with vfs_glusterfs
+#endifarch
 %endif
 
 # Build the ctdb-pcp-pmda package by default on Fedora

--- a/packaging/samba-4.22.spec.j2
+++ b/packaging/samba-4.22.spec.j2
@@ -50,11 +50,12 @@
 #endifarch
 %endif
 
-%bcond_with vfs_glusterfs
-%ifarch ppc64le s390x x86_64
-%if (0%{?rhel} && 0%{?centos}) || 0%{?fedora}
+# Build vfs_glusterfs module by default
+%ifarch aarch64 ppc64le s390x x86_64
 %bcond_without vfs_glusterfs
-%endif
+%else
+%bcond_with vfs_glusterfs
+#endifarch
 %endif
 
 # Build the ctdb-pcp-pmda package by default on Fedora

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -50,11 +50,12 @@
 #endifarch
 %endif
 
-%bcond_with vfs_glusterfs
-%ifarch ppc64le s390x x86_64
-%if (0%{?rhel} && 0%{?centos}) || 0%{?fedora}
+# Build vfs_glusterfs module by default
+%ifarch aarch64 ppc64le s390x x86_64
 %bcond_without vfs_glusterfs
-%endif
+%else
+%bcond_with vfs_glusterfs
+#endifarch
 %endif
 
 # Build the ctdb-pcp-pmda package by default on Fedora


### PR DESCRIPTION
- Switch to Storage SIG repo for GlusterFS because nightly glusterfs repo doesn't have aarch64 packages.
- Rearrange and enable building samba-vfs-glusterfs on aarch64.