### PR TITLE
rpmspec: Remove unwanted excludes for ceph and gluster manpages

### DIFF
--- a/packaging/samba-4.21.spec.j2
+++ b/packaging/samba-4.21.spec.j2
@@ -1193,6 +1193,9 @@ export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
 %if %{without vfs_glusterfs}
         --disable-glusterfs \
 %endif
+%if %{without vfs_cephfs}
+        --disable-cephfs \
+%endif
 %if %{with clustering}
         --with-cluster-support \
 %endif
@@ -1685,16 +1688,6 @@ fi
 %{_mandir}/man8/vfs_worm.8*
 %{_mandir}/man8/vfs_xattr_tdb.8*
 %{_mandir}/man8/vfs_widelinks.8*
-
-%if %{without vfs_glusterfs}
-%exclude %{_mandir}/man8/vfs_glusterfs.8*
-%endif
-
-%if %{without vfs_cephfs}
-%exclude %{_mandir}/man8/vfs_ceph.8*
-%exclude %{_mandir}/man8/vfs_ceph_new.8*
-%exclude %{_mandir}/man8/vfs_ceph_snapshots.8*
-%endif
 
 %attr(775,root,printadmin) %dir /var/lib/samba/drivers
 

--- a/packaging/samba-4.22.spec.j2
+++ b/packaging/samba-4.22.spec.j2
@@ -1186,6 +1186,9 @@ export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
 %if %{without vfs_glusterfs}
         --disable-glusterfs \
 %endif
+%if %{without vfs_cephfs}
+        --disable-cephfs \
+%endif
 %if %{with clustering}
         --with-cluster-support \
 %endif
@@ -1678,16 +1681,6 @@ fi
 %{_mandir}/man8/vfs_worm.8*
 %{_mandir}/man8/vfs_xattr_tdb.8*
 %{_mandir}/man8/vfs_widelinks.8*
-
-%if %{without vfs_glusterfs}
-%exclude %{_mandir}/man8/vfs_glusterfs.8*
-%endif
-
-%if %{without vfs_cephfs}
-%exclude %{_mandir}/man8/vfs_ceph.8*
-%exclude %{_mandir}/man8/vfs_ceph_new.8*
-%exclude %{_mandir}/man8/vfs_ceph_snapshots.8*
-%endif
 
 %attr(775,root,printadmin) %dir /var/lib/samba/drivers
 

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1197,6 +1197,9 @@ export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
 %if %{without vfs_glusterfs}
         --disable-glusterfs \
 %endif
+%if %{without vfs_cephfs}
+        --disable-cephfs \
+%endif
 %if %{with clustering}
         --with-cluster-support \
 %endif
@@ -1697,16 +1700,6 @@ fi
 %{_mandir}/man8/vfs_worm.8*
 %{_mandir}/man8/vfs_xattr_tdb.8*
 %{_mandir}/man8/vfs_widelinks.8*
-
-%if %{without vfs_glusterfs}
-%exclude %{_mandir}/man8/vfs_glusterfs.8*
-%endif
-
-%if %{without vfs_cephfs}
-%exclude %{_mandir}/man8/vfs_ceph.8*
-%exclude %{_mandir}/man8/vfs_ceph_new.8*
-%exclude %{_mandir}/man8/vfs_ceph_snapshots.8*
-%endif
 
 %attr(775,root,printadmin) %dir /var/lib/samba/drivers
 


### PR DESCRIPTION
If we are building without ceph or gluster (`--without-cephfs` or `--without-glusterfs`) we are supposed to add the corresponding configure options thereby avoid building the respective man pages.