### PR TITLE
Fix failures in building RPMs on Fedora 43

### DIFF
--- a/packaging/samba-4.22.spec.j2
+++ b/packaging/samba-4.22.spec.j2
@@ -143,6 +143,8 @@ Source14:       samba.pamd
 
 Source201:      README.downgrade
 
+Patch1:         samba-ctdb-pmda.patch
+
 Requires(pre): /usr/sbin/groupadd
 Requires(post): systemd
 Requires(preun): systemd

--- a/packaging/samba-4.22.spec.j2
+++ b/packaging/samba-4.22.spec.j2
@@ -140,12 +140,13 @@ Source11:       smb.conf.vendor
 Source12:       smb.conf.example
 Source13:       pam_winbind.conf
 Source14:       samba.pamd
+Source15:       samba-systemd-sysusers.conf
+Source16:       samba-winbind-systemd-sysusers.conf
 
 Source201:      README.downgrade
 
 Patch1:         samba-ctdb-pmda.patch
 
-Requires(pre): /usr/sbin/groupadd
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
@@ -1290,6 +1291,10 @@ echo "d /run/samba  755 root root" > %{buildroot}%{_tmpfilesdir}/samba.conf
 echo "d /run/ctdb 755 root root" > %{buildroot}%{_tmpfilesdir}/ctdb.conf
 %endif
 
+install -d -m 0755 %{buildroot}%{_sysusersdir}
+install -m 0644 %{SOURCE15} %{buildroot}%{_sysusersdir}/samba.conf
+install -m 0644 %{SOURCE16} %{buildroot}%{_sysusersdir}/samba-winbind.conf
+
 install -d -m 0755 %{buildroot}%{_sysconfdir}/sysconfig
 install -m 0644 packaging/systemd/samba.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/samba
 %if %{with clustering}
@@ -1407,7 +1412,7 @@ TDB_NO_FSYNC=1 make %{?_smp_mflags} test FAIL_IMMEDIATELY=1
 %systemd_postun_with_restart nmb.service
 
 %pre common
-getent group printadmin >/dev/null || groupadd -r printadmin || :
+%sysusers_create_compat %{SOURCE15}
 
 %post common
 %{?ldconfig}
@@ -1516,7 +1521,7 @@ fi
 %ldconfig_scriptlets test
 
 %pre winbind
-/usr/sbin/groupadd -g 88 wbpriv >/dev/null 2>&1 || :
+%sysusers_create_compat %{SOURCE16}
 
 %post winbind
 %systemd_post winbind.service
@@ -1897,6 +1902,7 @@ fi
 ### COMMON
 %files common
 %{_tmpfilesdir}/samba.conf
+%{_sysusersdir}/samba.conf
 %dir %{_sysconfdir}/logrotate.d/
 %config(noreplace) %{_sysconfdir}/logrotate.d/samba
 %attr(0700,root,root) %dir /var/log/samba
@@ -2612,6 +2618,7 @@ fi
 %{_libdir}/samba/libnss-info-private-samba.so
 %{_libdir}/samba/libidmap-private-samba.so
 %{_sbindir}/winbindd
+%{_sysusersdir}/samba-winbind.conf
 %attr(750,root,wbpriv) %dir /var/lib/samba/winbindd_privileged
 %{_unitdir}/winbind.service
 %{_prefix}/lib/NetworkManager

--- a/packaging/samba-4.23.spec.j2
+++ b/packaging/samba-4.23.spec.j2
@@ -144,10 +144,11 @@ Source11:       smb.conf.vendor
 Source12:       smb.conf.example
 Source13:       pam_winbind.conf
 Source14:       samba.pamd
+Source15:       samba-systemd-sysusers.conf
+Source16:       samba-winbind-systemd-sysusers.conf
 
 Source201:      README.downgrade
 
-Requires(pre): /usr/sbin/groupadd
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
@@ -1307,6 +1308,10 @@ echo "d /run/samba  755 root root" > %{buildroot}%{_tmpfilesdir}/samba.conf
 echo "d /run/ctdb 755 root root" > %{buildroot}%{_tmpfilesdir}/ctdb.conf
 %endif
 
+install -d -m 0755 %{buildroot}%{_sysusersdir}
+install -m 0644 %{SOURCE15} %{buildroot}%{_sysusersdir}/samba.conf
+install -m 0644 %{SOURCE16} %{buildroot}%{_sysusersdir}/samba-winbind.conf
+
 install -d -m 0755 %{buildroot}%{_sysconfdir}/sysconfig
 install -m 0644 packaging/systemd/samba.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/samba
 %if %{with clustering}
@@ -1424,7 +1429,7 @@ TDB_NO_FSYNC=1 make %{?_smp_mflags} test FAIL_IMMEDIATELY=1
 %systemd_postun_with_restart nmb.service
 
 %pre common
-getent group printadmin >/dev/null || groupadd -r printadmin || :
+%sysusers_create_compat %{SOURCE15}
 
 %post common
 %{?ldconfig}
@@ -1533,7 +1538,7 @@ fi
 %ldconfig_scriptlets test
 
 %pre winbind
-/usr/sbin/groupadd -g 88 wbpriv >/dev/null 2>&1 || :
+%sysusers_create_compat %{SOURCE16}
 
 %post winbind
 %systemd_post winbind.service
@@ -1923,6 +1928,7 @@ fi
 ### COMMON
 %files common
 %{_tmpfilesdir}/samba.conf
+%{_sysusersdir}/samba.conf
 %dir %{_sysconfdir}/logrotate.d/
 %config(noreplace) %{_sysconfdir}/logrotate.d/samba
 %attr(0700,root,root) %dir /var/log/samba
@@ -2654,6 +2660,7 @@ fi
 %{_libdir}/samba/libnss-info-private-samba.so
 %{_libdir}/samba/libidmap-private-samba.so
 %{_sbindir}/winbindd
+%{_sysusersdir}/samba-winbind.conf
 %attr(750,root,wbpriv) %dir /var/lib/samba/winbindd_privileged
 %{_unitdir}/winbind.service
 %{_prefix}/lib/NetworkManager

--- a/packaging/samba-ctdb-pmda.patch
+++ b/packaging/samba-ctdb-pmda.patch
@@ -1,0 +1,130 @@
+From 069aff6b3e7685f3886d1a06bfe01f6fde297770 Mon Sep 17 00:00:00 2001
+From: Alexander Bokovoy <ab@samba.org>
+Date: Wed, 3 Sep 2025 15:42:46 +0300
+Subject: [PATCH 1/2] ctdb: fix build against PCP 7.0.0
+
+BUG: https://bugzilla.samba.org/show_bug.cgi?id=15904
+
+Signed-off-by: Alexander Bokovoy <ab@samba.org>
+Reviewed-by: Martin Schwenke <martin@meltin.net>
+
+Autobuild-User(master): Martin Schwenke <martins@samba.org>
+Autobuild-Date(master): Mon Sep  8 04:47:37 UTC 2025 on atb-devel-224
+
+(cherry picked from commit 83ff87f3dab0d6b22031614e9481b880f1dd99e8)
+---
+ ctdb/utils/pmda/pmda_ctdb.c | 11 ++++++++++-
+ ctdb/wscript                | 21 +++++++++++----------
+ 2 files changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/ctdb/utils/pmda/pmda_ctdb.c b/ctdb/utils/pmda/pmda_ctdb.c
+index 9df7f780652..3af54827501 100644
+--- a/ctdb/utils/pmda/pmda_ctdb.c
++++ b/ctdb/utils/pmda/pmda_ctdb.c
+@@ -41,10 +41,19 @@
+ 
+ #define pmID_cluster(id)	id->cluster
+ #define pmID_item(id)		id->item
++#endif
++
++#ifndef HAVE_PMGETPROGNAME
+ #define pmGetProgname()		pmProgname
++#endif
++#ifndef HAVE_PMSETPROGNAME
+ #define pmSetProgname(a)	__pmSetProgname(a)
+ #endif
+ 
++#ifdef HAVE_STRUCT_PMRESULT
++#define pmdaResult pmResult
++#endif
++
+ #include "domain.h"
+ 
+ /*
+@@ -451,7 +460,7 @@ err_out:
+  * instance domain evaluation.
+  */
+ static int
+-pmda_ctdb_fetch(int numpmid, pmID pmidlist[], pmResult **resp, pmdaExt *pmda)
++pmda_ctdb_fetch(int numpmid, pmID pmidlist[], pmdaResult **resp, pmdaExt *pmda)
+ {
+ 	int ret;
+ 
+diff --git a/ctdb/wscript b/ctdb/wscript
+index e9cd89436a3..6ab68dce870 100644
+--- a/ctdb/wscript
++++ b/ctdb/wscript
+@@ -226,16 +226,17 @@ def configure(conf):
+ 
+     have_pmda = False
+     if Options.options.ctdb_pmda:
+-        pmda_support = True
+-
+-        if not conf.CHECK_HEADERS('pcp/pmapi.h pcp/impl.h pcp/pmda.h',
+-                                  together=True):
+-            pmda_support = False
+-        if not conf.CHECK_FUNCS_IN('pmProgname', 'pcp'):
+-            pmda_support = False
+-        if not conf.CHECK_FUNCS_IN('pmdaDaemon', 'pcp_pmda'):
+-            pmda_support = False
+-        if pmda_support:
++        checks = [conf.CHECK_HEADERS('pcp/pmapi.h pcp/impl.h pcp/pmda.h',
++                                     together=True),
++                  conf.CHECK_FUNCS_IN('pmdaDaemon', 'pcp_pmda')]
++
++        have_progname = [conf.CHECK_FUNCS_IN('pmProgname', 'pcp'),
++                         conf.CHECK_FUNCS_IN('pmGetProgname', 'pcp'),
++                         conf.CHECK_FUNCS_IN('pmSetProgname', 'pcp')]
++
++        conf.CHECK_TYPE_IN('struct pmResult', 'pcp/pmapi.h')
++
++        if all(checks) and any(have_progname):
+             conf.CHECK_TYPE_IN('__pmID_int', 'pcp/pmapi.h pcp/impl.h')
+             have_pmda = True
+         else:
+-- 
+2.52.0
+
+
+From 7f184acb53f786f3bffb61569da280ab3b8b8e31 Mon Sep 17 00:00:00 2001
+From: Andreas Schneider <asn@samba.org>
+Date: Fri, 12 Sep 2025 15:37:38 +0200
+Subject: [PATCH 2/2] ctdb: Fix redefinitoin of pmdaResult
+
+../../ctdb/utils/pmda/pmda_ctdb.c:52:9: warning: 'pmdaResult' redefined
+   52 | #define pmdaResult pmResult
+      |         ^~~~~~~~~~
+In file included from ../../ctdb/utils/pmda/pmda_ctdb.c:35:
+/usr/include/pcp/pmda.h:30:9: note: this is the location of the previous definition
+   30 | #define pmdaResult pmResult_v2
+      |         ^~~~~~~~~~
+
+BUG: https://bugzilla.samba.org/show_bug.cgi?id=15904
+
+Signed-off-by: Andreas Schneider <asn@samba.org>
+Reviewed-by: Alexander Bokovoy <ab@samba.org>
+
+Autobuild-User(master): Andreas Schneider <asn@cryptomilk.org>
+Autobuild-Date(master): Sat Sep 13 08:12:42 UTC 2025 on atb-devel-224
+
+(cherry picked from commit d4b448c305f674646001e293d8aa6ebc0ca6dc77)
+---
+ ctdb/utils/pmda/pmda_ctdb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ctdb/utils/pmda/pmda_ctdb.c b/ctdb/utils/pmda/pmda_ctdb.c
+index 3af54827501..edf6ffc136b 100644
+--- a/ctdb/utils/pmda/pmda_ctdb.c
++++ b/ctdb/utils/pmda/pmda_ctdb.c
+@@ -50,7 +50,7 @@
+ #define pmSetProgname(a)	__pmSetProgname(a)
+ #endif
+ 
+-#ifdef HAVE_STRUCT_PMRESULT
++#if !defined(pmdaResult) && defined(HAVE_STRUCT_PMRESULT)
+ #define pmdaResult pmResult
+ #endif
+ 
+-- 
+2.52.0
+

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -150,10 +150,11 @@ Source11:       smb.conf.vendor
 Source12:       smb.conf.example
 Source13:       pam_winbind.conf
 Source14:       samba.pamd
+Source15:       samba-systemd-sysusers.conf
+Source16:       samba-winbind-systemd-sysusers.conf
 
 Source201:      README.downgrade
 
-Requires(pre): /usr/sbin/groupadd
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
@@ -1315,6 +1316,10 @@ echo "d /run/samba  755 root root" > %{buildroot}%{_tmpfilesdir}/samba.conf
 echo "d /run/ctdb 755 root root" > %{buildroot}%{_tmpfilesdir}/ctdb.conf
 %endif
 
+install -d -m 0755 %{buildroot}%{_sysusersdir}
+install -m 0644 %{SOURCE15} %{buildroot}%{_sysusersdir}/samba.conf
+install -m 0644 %{SOURCE16} %{buildroot}%{_sysusersdir}/samba-winbind.conf
+
 install -d -m 0755 %{buildroot}%{_sysconfdir}/sysconfig
 install -m 0644 packaging/systemd/samba.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/samba
 %if %{with clustering}
@@ -1432,7 +1437,7 @@ TDB_NO_FSYNC=1 make %{?_smp_mflags} test FAIL_IMMEDIATELY=1
 %systemd_postun_with_restart nmb.service
 
 %pre common
-getent group printadmin >/dev/null || groupadd -r printadmin || :
+%sysusers_create_compat %{SOURCE15}
 
 %post common
 %{?ldconfig}
@@ -1541,7 +1546,7 @@ fi
 %ldconfig_scriptlets test
 
 %pre winbind
-/usr/sbin/groupadd -g 88 wbpriv >/dev/null 2>&1 || :
+%sysusers_create_compat %{SOURCE16}
 
 %post winbind
 %systemd_post winbind.service
@@ -1933,6 +1938,7 @@ fi
 ### COMMON
 %files common
 %{_tmpfilesdir}/samba.conf
+%{_sysusersdir}/samba.conf
 %dir %{_sysconfdir}/logrotate.d/
 %config(noreplace) %{_sysconfdir}/logrotate.d/samba
 %attr(0700,root,root) %dir /var/log/samba
@@ -2668,6 +2674,7 @@ fi
 %{_libdir}/samba/libnss-info-private-samba.so
 %{_libdir}/samba/libidmap-private-samba.so
 %{_sbindir}/winbindd
+%{_sysusersdir}/samba-winbind.conf
 %attr(750,root,wbpriv) %dir /var/lib/samba/winbindd_privileged
 %{_unitdir}/winbind.service
 %{_prefix}/lib/NetworkManager

--- a/packaging/samba-systemd-sysusers.conf
+++ b/packaging/samba-systemd-sysusers.conf
@@ -1,0 +1,2 @@
+#Type Name       ID
+g     printadmin -

--- a/packaging/samba-winbind-systemd-sysusers.conf
+++ b/packaging/samba-winbind-systemd-sysusers.conf
@@ -1,0 +1,2 @@
+#Type Name       ID
+g     wbpriv     88


### PR DESCRIPTION
- The updated version of PMDA caused build failures ([bz#15904](https://bugzilla.samba.org/show_bug.cgi?id=15904)) on Fedora 43, so the fixes need to be backported to the 4.22 spec file.
- The dependency on the _groupadd_ utility to create groups (as a _%pre_ stage task) bit us during the installation test of the built Fedora 43 RPMs because the corresponding `Provides:` for `group(printadmin)` and `group(wbpriv)` were somehow missing (refer [93ae555](https://src.fedoraproject.org/rpms/samba/c/93ae555a841585d369e18cc22469d0a345c9e0d4?branch=rawhide) and [f245ed7](https://src.fedoraproject.org/rpms/samba/c/f245ed7ba22cd3c5fbe9c3a603e182c5ff2baaa5?branch=rawhide)).