### PR TITLE
roles/build.rpms.rhel: set --cgroup-manager when building in a container

### DIFF
--- a/ansible/roles/build.rpms.rhel/tasks/main.yml
+++ b/ansible/roles/build.rpms.rhel/tasks/main.yml
@@ -12,6 +12,8 @@
     command: /tmp/files/rpm-build.sh
     detach: false
     rm: true
+    cmd_args:
+      - "--cgroup-manager=cgroupfs"
     volume:
       - "{{ role_path }}/files:/tmp/files:z"
       - "{{ build_dir }}:{{ build_dir }}:z"


### PR DESCRIPTION
this avoids the following issue when building in SPS on arm64:

Error: OCI runtime error: crun: systemd failed to install eBPF device filter on cgroup