### PR TITLE
rpmspec: Add new sub-package for vfs_ceph_rgw

### DIFF
--- a/ansible/build.rpms.centos.yml
+++ b/ansible/build.rpms.centos.yml
@@ -7,7 +7,7 @@
     os_vers: "{{ version | default('9') }}"
     os_arch: "{{ arch | default('x86_64') }}"
     vendor_dist: "{{ vendor_dist_suffix | default('%{nil}') }}"
-    mock_config: "{{ lookup('fileglob', mock_dir + '/centos-stream*-{{ os_vers }}-{{ os_arch }}.cfg') }}"
+    mock_config: "{{ lookup('fileglob', mock_dir + '/centos-stream*-' + os_vers + '-' + os_arch + '.cfg') }}"
   vars_files:
     - vars.yml
   roles:

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -93,6 +93,8 @@
 %bcond_with varlink
 %endif
 
+%bcond_without vfs_cephrgw
+
 %global baserelease 1
 
 %global samba_version {{ samba_rpm_version }}
@@ -287,6 +289,10 @@ BuildRequires: libglusterfs-devel >= 3.4.0.16
 
 %if %{with vfs_cephfs}
 BuildRequires: libcephfs-devel
+%endif
+
+%if %{with vfs_cephrgw}
+BuildRequires: librgw-devel
 %endif
 
 %if %{with vfs_io_uring}
@@ -620,6 +626,21 @@ Provides: bundled(libreplace)
 %description vfs-cephfs
 Samba VFS module for Ceph distributed storage system integration.
 #endif {with vfs_cephfs}
+%endif
+
+%if %{with vfs_cephrgw}
+%package vfs-cephrgw
+Summary: Samba VFS module for Ceph RGW
+Requires: librgw2
+Requires: %{name} = %{samba_depver}
+Requires: %{name}-client-libs = %{samba_depver}
+Requires: %{name}-libs = %{samba_depver}
+
+Provides: bundled(libreplace)
+
+%description vfs-cephrgw
+Samba VFS module for Ceph RGW integration.
+#endif {with vfs_cephrgw}
 %endif
 
 ### IOURING
@@ -1222,6 +1243,9 @@ export python_LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl,-z,defs//g')"
 %endif
 %if %{without vfs_cephfs}
         --disable-cephfs \
+%endif
+%if %{without vfs_cephrgw}
+        --disable-cephrgw \
 %endif
 %if %{with clustering}
         --with-cluster-support \
@@ -2280,6 +2304,13 @@ fi
 %{_libdir}/samba/vfs/ceph_new.so
 %{_mandir}/man8/vfs_ceph.8*
 %{_mandir}/man8/vfs_ceph_new.8*
+%endif
+
+### VFS-CEPHRGW
+%if %{with vfs_cephrgw}
+%files vfs-cephrgw
+%{_libdir}/samba/vfs/ceph_rgw.so
+%{_mandir}/man8/vfs_ceph_rgw.8*
 %endif
 
 ### VFS-IOURING


### PR DESCRIPTION
- Fix the following error seen with newer ansible versions:
```
[ERROR]: Task failed: Module failed: Destination [] does not exist !
Origin: /home/anoopcs/workspace/samba-build.git/ansible/roles/prep.dirs/tasks/repo.yml:1:3

1 - name: adapt mock config to use additional template for glusterfs
    ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Destination [] does not exist !", "rc": 257}
```
- [!4381](gitlab.com/samba-team/samba/-/merge_requests/4381) added a new VFS module for Ceph RGW integration. This is now separately packaged.