### PR TITLE
ansible/build.rpms.rhel: set network to host

### DIFF
--- a/ansible/roles/build.rpms.rhel/tasks/main.yml
+++ b/ansible/roles/build.rpms.rhel/tasks/main.yml
@@ -12,6 +12,7 @@
     command: /tmp/files/rpm-build.sh
     detach: false
     rm: true
+    network: host
     volume:
       - "{{ role_path }}/files:/tmp/files:z"
       - "{{ build_dir }}:{{ build_dir }}:z"


### PR DESCRIPTION
avoiding network issues on SPS amd64 nodes

Container rhel_samba_build exited with code 70 when runed

Network error: Name or service not known (error code -2)